### PR TITLE
Cambios menores para mejorar el funcionamiento del comando INVITE

### DIFF
--- a/pkg/modelo/recepcion.go
+++ b/pkg/modelo/recepcion.go
@@ -23,17 +23,12 @@ func NuevaRecepcion() *Recepcion {
  * Añade al cliente a la sala de chat.
  */
 func (recepcion *Recepcion) Agrega(conexion *Conexion) {
-	recepcion.conexiones = append(recepcion.conexiones, conexion)
+	recepcion.conexiones[conexion] = true
 }
 
 /**
  * Elimina al cliente de la recepción.
  */
 func (recepcion *Recepcion) Elimina(conexion *Conexion) {
-	for i, otherConexion := range recepcion.conexiones {
-		if conexion == otherConexion {
-			recepcion.conexiones = append(recepcion.conexiones[:i], recepcion.conexiones[i+1:]...)
-			break
-		}
-	}
+	delete (recepcion.conexiones, conexion)
 }


### PR DESCRIPTION
y reducir las lineas de codigo.

En particular, la estructura que guarda a los clientes en el servidor se cambió de una rebanada a un diccionario, pues la mayoría de las acciones que se llevan a cabo en el nuevo protocolo dependen del nombre de usuario de cada cliente.